### PR TITLE
Update Archive naming so a version isn't included

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,10 +23,11 @@ builds:
 
 
 archives:
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    amd64: x86_64
+  name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}{{ if .Mips }}_{{ .Mips }}{{ end }}"
+  - replacements:
+      darwin: Darwin
+      linux: Linux
+      amd64: x86_64
 
 brews:
   - name: ecs-runner

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ go build -mod vendor ./cmd/stabilizer
 
 ## Install 
 
+MacOS:
+
 ```bash
 brew install ministryofjustice/opg/ecs-runner
 ```


### PR DESCRIPTION
this is so that `releases/latest/download/<name_of_file>` can be used