### PR TITLE
Pin goreleaser v1.18.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,6 +40,7 @@ jobs:
       - name: goreleaser
         uses: goreleaser/goreleaser-action@v3
         with:
+          version: 1.18.2
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
Although the goreleaser action is pinned to `v3`, the backend goreleaser version isn't pinned so has updated to `1.19.1`

This has broken the release pipeline, so I'm pinning to the last working version , `1.18.2`, for now
